### PR TITLE
Add school id into login parameter

### DIFF
--- a/docs/Dulwich-Bookings-API.postman_collection.json
+++ b/docs/Dulwich-Bookings-API.postman_collection.json
@@ -29,7 +29,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"email\": \"student23@stu.dulwich.org\",\n    \"password\": \"asdasd\"\n}",
+              "raw": "{\n    \"email\": \"student23@stu.dulwich.org\",\n    \"password\": \"asdasd\",\n    \"schoolId\": 1\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -64,7 +64,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"email\": \"teacher@dulwich.org\",\n    \"password\": \"asdasd\"\n}",
+              "raw": "{\n    \"email\": \"teacher@dulwich.org\",\n    \"password\": \"asdasd\",\n    \"schoolId\": 1\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -99,7 +99,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"email\": \"admin@dulwich.org\",\n    \"password\": \"asdasd\"\n}",
+              "raw": "{\n    \"email\": \"admin@dulwich.org\",\n    \"password\": \"asdasd\",\n    \"schoolId\": 1\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -248,7 +248,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"email\": \"shenyicui@outlook.com\"\n}",
+              "raw": "{\n    \"email\": \"shenyicui@outlook.com\",\n    \"schoolId\": 1\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/src/middlewares/parseBulkUserCsv.ts
+++ b/src/middlewares/parseBulkUserCsv.ts
@@ -5,7 +5,8 @@ import fs from 'fs';
 import userFriendlyMessages from '../consts/userFriendlyMessages';
 import {BulkSignUpAttributes, Role} from '../models/User';
 
-const parseCsv = (req: Request, res: Response, next: NextFunction) => {
+// Format for bulk user CSV file: [email], [role], [class?]
+const parseBulkUserCsv = (req: Request, res: Response, next: NextFunction) => {
   try {
     if (!req.file?.path) {
       res.status(400);
@@ -37,4 +38,4 @@ const parseCsv = (req: Request, res: Response, next: NextFunction) => {
   }
 };
 
-export default parseCsv;
+export default parseBulkUserCsv;

--- a/src/routes/AuthenticationRoutes.ts
+++ b/src/routes/AuthenticationRoutes.ts
@@ -3,7 +3,7 @@ import express, {Request, Response, NextFunction} from 'express';
 import AuthenticationController from '../controllers/AuthenticationController';
 import Container from '../utils/container';
 import uploadFile from '../middlewares/uploadFile';
-import parseCsv from '../middlewares/parseCsv';
+import parseBulkUserCsv from '../middlewares/parseBulkUserCsv';
 import AuthenticationMiddleware from '../middlewares/authentication';
 import roleValidator, {ADMINS} from '../middlewares/authorization';
 
@@ -39,7 +39,7 @@ export default () => {
 
   authenticationRouter.post(
     '/bulkSignUp',
-    [auth, roleValidator(ADMINS), uploadFile, parseCsv],
+    [auth, roleValidator(ADMINS), uploadFile, parseBulkUserCsv],
     authenticationController.bulkSignUp.bind(authenticationController)
   );
 

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -25,18 +25,35 @@ export default class UserService {
     )[0] as User;
   }
 
-  async getOneUserByEmail(email: string, showPassword = false) {
+  async getOneUserByEmailAndSchoolId(
+    email: string,
+    schoolId: number,
+    showPassword = false
+  ) {
     return (
       await (showPassword
-        ? this.userRepository.getScopeWithFilters({email}, 'withPassword')
-        : this.userRepository.getWithFilters({email}))
+        ? this.userRepository.getScopeWithFilters(
+            {email, schoolId},
+            'withPassword'
+          )
+        : this.userRepository.getWithFilters({email, schoolId}))
     )[0] as User;
   }
 
-  async bulkGetUserByEmails(emails: string[], showPassword = false) {
+  async bulkGetUserByEmailsAndSchoolId(
+    emails: string[],
+    schoolId: number,
+    showPassword = false
+  ) {
     return (await (showPassword
-      ? this.userRepository.getScopeWithFilters({email: emails}, 'withPassword')
-      : this.userRepository.getWithFilters({email: emails}))) as User[];
+      ? this.userRepository.getScopeWithFilters(
+          {email: emails, schoolId},
+          'withPassword'
+        )
+      : this.userRepository.getWithFilters({
+          email: emails,
+          schoolId,
+        }))) as User[];
   }
 
   async createOneUser(user: UserCreationAttributes) {


### PR DESCRIPTION
## Changes
- Updated query methods in `UserService` to take in both `email` and `schoolId` when looking for user.
- Modified `signUp` and `bulkSignUp` and `forgetPasswordEmail` and `signIn` methods in `AuthenticationController` to query existing users using both `email(s)` and **`schoolId`**.

## Testing
- Updated Postman docs with new `SchoolId` parameter for authentication.

## Issues
- Resolves #23 