### PR TITLE
Add colors column to tag

### DIFF
--- a/docs/Dulwich-Bookings-API.postman_collection.json
+++ b/docs/Dulwich-Bookings-API.postman_collection.json
@@ -346,7 +346,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\":\"Test\"\n}",
+              "raw": "{\n    \"name\": \"Test\",\n    \"colour\": \"#AAAAAA\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -374,7 +374,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"new name\"\n}",
+              "raw": "{\n    \"name\": \"new name\",\n    \"colour\": \"#123456\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -382,9 +382,9 @@
               }
             },
             "url": {
-              "raw": "{{hostname}}/tags/1",
+              "raw": "{{hostname}}/tags/7",
               "host": ["{{hostname}}"],
-              "path": ["tags", "1"]
+              "path": ["tags", "7"]
             }
           },
           "response": []

--- a/src/consts/userFriendlyMessages.ts
+++ b/src/consts/userFriendlyMessages.ts
@@ -47,6 +47,7 @@ export default {
     createTag: 'Error in created Tag.',
     updateTag: 'Error in updated Tag.',
     deleteTag: 'Error in deleted Tag.',
+    invalidColour: 'Colour is not in hex colour code format.',
 
     getOneUser: 'Error in retrieving User.',
     getAllUsers: 'Error in retrieving Users.',

--- a/src/db/migrations/20220705120624-add-colour-tag.js
+++ b/src/db/migrations/20220705120624-add-colour-tag.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('tag', 'colour', {
+      type: Sequelize.STRING,
+      defaultValue: '#FFFFFF',
+      allowNull: false,
+    });
+  },
+  async down(queryInterface) {
+    await queryInterface.removeColumn('tag', 'colour');
+  },
+};

--- a/src/db/seeders/20220515090957-sample-tag.js
+++ b/src/db/seeders/20220515090957-sample-tag.js
@@ -5,31 +5,37 @@ module.exports = {
     return await queryInterface.bulkInsert('tag', [
       {
         name: 'Math',
+        colour: '#264653',
         createdAt: new Date(),
         updatedAt: new Date(),
       },
       {
         name: 'Science',
+        colour: '#2A9D8F',
         createdAt: new Date(),
         updatedAt: new Date(),
       },
       {
         name: 'Geography',
+        colour: '#E9C46A',
         createdAt: new Date(),
         updatedAt: new Date(),
       },
       {
         name: 'History',
+        colour: '#F4A261',
         createdAt: new Date(),
         updatedAt: new Date(),
       },
       {
         name: 'Economics',
+        colour: '#E76F51',
         createdAt: new Date(),
         updatedAt: new Date(),
       },
       {
         name: 'SE21',
+        colour: '#EAE2B7',
         createdAt: new Date(),
         updatedAt: new Date(),
       },


### PR DESCRIPTION
## Changes
- Add new column `colour` to `tag` model
- Add validator to check if `colour` is in hex colour code before create/update
- Update seed data for `tag` to include `colour`

## Testing
- Update `Tags` collection in Postman docs.

## Issues
- Resolves #35 